### PR TITLE
Get the version number by reading loads/__init__

### DIFF
--- a/loads/__init__.py
+++ b/loads/__init__.py
@@ -1,4 +1,7 @@
+import pkg_resources
+
 from loads import _patch  # NOQA
+from loads.case import TestCase  # NOQA
 
 
-__version__ = '0.1'
+__version__ = pkg_resources.get_distribution('loads').version

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
+
 from setuptools import setup, find_packages
-from loads import __version__
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -19,7 +19,7 @@ requires = ['pyzmq', 'psutil', 'gevent', 'requests', 'ws4py', 'webtest',
 
 
 setup(name='loads',
-      version=__version__,
+      version='0.1.0',
       packages=find_packages(),
       include_package_data=True,
       description='Implementation of the Request-Reply Broker pattern in ZMQ',


### PR DESCRIPTION
I'm not a big fan of this solution, but the alternatives are worse, I think:
- introduce dependencies to run the setup.py (which we don't want)
- duplicate the version information (I did that in pelican and that's a bit of a pain)

Maybe there are other ways to do that better I'm not considering here?
