### PR TITLE
Don't overwrite TestCase.server_url with None.

### DIFF
--- a/loads/case.py
+++ b/loads/case.py
@@ -20,13 +20,16 @@ MAX_CON = 1000
 
 
 class TestCase(unittest.TestCase):
+
+    server_url = None
+
     def __init__(self, test_name, test_result=None, config=None):
         super(TestCase, self).__init__(test_name)
         if config is None:
             config = {}
         self.config = config
-        self.server_url = config.get('server_url',
-                                     getattr(self, 'server_url', None))
+        if config.get('server_url') is not None:
+            self.server_url = config['server_url']
         self._test_result = test_result
 
         self.session = Session(test=self, test_result=test_result)

--- a/loads/tests/test_case.py
+++ b/loads/tests/test_case.py
@@ -53,3 +53,12 @@ class TestTestCase(unittest.TestCase):
             self.assertEquals(test.server_url, 'http://notmyidea.org')
         finally:
             del _MyTestCase.server_url
+
+    def test_serverurl_is_not_overwrited_by_none(self):
+        _MyTestCase.server_url = 'http://example.org'
+        try:
+            test = _MyTestCase('test_one', test_result=mock.sentinel.results,
+                               config={'server_url': None})
+            self.assertEquals(test.server_url, 'http://example.org')
+        finally:
+            del _MyTestCase.server_url


### PR DESCRIPTION
The passed-in config could have server_url=None is it's not specified in
the config or command-line options.  This should not overwrite an explicit
value of server_url from the class.
