### PR TITLE
Fix ssh default venv location

### DIFF
--- a/loads/deploy/ssh.py
+++ b/loads/deploy/ssh.py
@@ -17,7 +17,7 @@ class LoadsHost(Host):
                '--force-yes install %s')
 
         for package in packages:
-            self.execute(cmd % package,  ignore_error=True)
+            self.execute(cmd % package, ignore_error=True)
 
     def check_circus(self, endpoint):
         cmd = 'cd %s;' % self.venv


### PR DESCRIPTION
I had several tests failures because the SSH Loads environment was being done in /tmp/loads by default, which can conflict with the one created to hold results. 

Changing the path to /tmp/loads-venv fixes it.
