### PR TITLE
External runner proc cleanup

### DIFF
--- a/loads/runners/external.py
+++ b/loads/runners/external.py
@@ -103,12 +103,11 @@ class ExternalRunner(LocalRunner):
                 return
             else:
                 # Wait for all the tests to finish and exit
-                if self._terminated is not None:
+                if self._terminated is None:
                     self._terminated = now
 
                 if (len(terminated) == len(self._processes)
-                        or self._terminated is not None
-                        and self._terminated + self._timeout > now):
+                        or now > self._terminated + self._timeout):
                     self._start_next_step()
 
         elif (len(terminated) == len(self._processes)


### PR DESCRIPTION
This changes the external runner to reap its child processes when they timeout, and to teardown any zmq sockets it has created.  Fixes https://github.com/mozilla-services/loads/issues/137 for me.

I moved the receiver socket setup code into _execute() so that it would be visually closer to its corresponding cleanup code.
