### PR TITLE
Make params parse more robust for key:value pairs

### DIFF
--- a/loads/tests/test_util.py
+++ b/loads/tests/test_util.py
@@ -96,6 +96,12 @@ class TestUtil(unittest2.TestCase):
         items.sort()
         self.assertEqual(items, [('one', '1'), ('two', '2')])
 
+    def test_decode_multiple_colons(self):
+        params = decode_params('one:tcp://foo|two:tcp://blah')
+        items = params.items()
+        items.sort()
+        self.assertEqual(items, [('one', 'tcp://foo'), ('two', 'tcp://blah')])
+
     def test_dump(self):
         dump = dump_stacks()
         num = len([l for l in dump if l.strip() == 'Greenlet'])

--- a/loads/transport/util.py
+++ b/loads/transport/util.py
@@ -108,7 +108,7 @@ def decode_params(params):
     """
     output_dict = {}
     for items in params.split('|'):
-        key, value = items.split(':')
+        key, value = items.split(':', 1)
         output_dict[key] = value
     return output_dict
 


### PR DESCRIPTION
I just stumbled across this code while playing around with the command line arguments.

Might be good to have it, not sure though :-)

It's here so that it won't get lost
