### PR TITLE
Specify python2.7 in the Makefile for the venv.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN = $(HERE)/bin
 PYTHON = $(BIN)/python
 
 INSTALL = $(BIN)/pip install --no-deps
-VTENV_OPTS ?= --distribute
+VTENV_OPTS ?= --distribute -p python2.7
 
 BUILD_DIRS = bin build include lib lib64 man share
 


### PR DESCRIPTION
Otherwise some distributions will try to install it with python 3.X
