### PR TITLE
Let `make build` fall back to python2.6 if python2.7 is not installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN = $(HERE)/bin
 PYTHON = $(BIN)/python
 
 INSTALL = $(BIN)/pip install --no-deps
-VTENV_OPTS ?= --distribute -p python2.7
+VTENV_OPTS ?= --distribute -p `which python2.7 python2.6 | head -n 1`
 
 BUILD_DIRS = bin build include lib lib64 man share
 


### PR DESCRIPTION
The AMIs we're currently using for picl-idp don't have python2.7, this lets `make build` use python2.6 as a fallback.
