### PR TITLE
Fallback on gevent.socket.gethostbyname.

### DIFF
--- a/loads/util.py
+++ b/loads/util.py
@@ -11,7 +11,7 @@ import math
 import fnmatch
 import random
 
-from gevent.socket import gethostbyname_ex
+from gevent import socket as gevent_socket
 
 
 logger = logging.getLogger('loads')
@@ -102,7 +102,14 @@ def dns_resolve(url):
     original = netloc[0]
     addrs = _DNS_CACHE.get(original)
     if addrs is None:
-        addrs = gethostbyname_ex(original)[2]
+        try:
+            addrs = gevent_socket.gethostbyname_ex(original)[2]
+        except AttributeError:
+            # gethostbyname_ex was introduced by gevent 1.0,
+            # fallback on gethostbyname instead.
+            logger.info('gevent.socket.gethostbyname_ex is not present, '
+                        'Falling-back on gevent.socket.gethostbyname')
+            addrs = [gevent_socket.gethostbyname(original)]
         _DNS_CACHE[original] = addrs
 
     resolved = random.choice(addrs)


### PR DESCRIPTION
When gevent.socket.gethostbyname_ex is not present.
