### PR TITLE
Don't include run_id in the agents if not known.

### DIFF
--- a/loads/transport/agent.py
+++ b/loads/transport/agent.py
@@ -182,7 +182,8 @@ class Agent(object):
         elif command in ('STATUS', '_STATUS'):
             status = {}
             run_id = data.get('run_id')
-            status['run_id'] = run_id
+            if run_id is not None:
+                status['run_id'] = run_id
 
             for pid, (proc, _run_id) in self._workers.items():
                 if run_id is not None and run_id != _run_id:


### PR DESCRIPTION
Fix #158.
