### PR TITLE
Print trailing newline when error has no traceback

### DIFF
--- a/loads/output/std.py
+++ b/loads/output/std.py
@@ -130,7 +130,9 @@ class StdOutput(object):
             sys.stderr.write("%d occurrences of: \n" % count)
             sys.stderr.write("    %s: %s" % (name, exc))
 
-            if tb not in (None, ''):   # XXX fix this
+            if tb in (None, ''):   # XXX fix this
+                sys.stderr.write('\n')
+            else:
                 if isinstance(tb, basestring):
                     sys.stderr.write(tb.replace('\n', '    \n'))
                 else:


### PR DESCRIPTION
I noticed that if you have an error with no traceback, it is printed without a trailing newline - fine if there's only one error, be really yuck when there are several and they get squished together.
