### PR TITLE
addError and addFailure are passed a tuple of 3 items, not one item.

### DIFF
--- a/loads/output/_funkload.py
+++ b/loads/output/_funkload.py
@@ -163,11 +163,11 @@ class FunkloadOutput(object):
 
     def addError(self, test, exc_info, loads_status, agent_id=None):
         test = self._get_test(test, loads_status, agent_id)
-        test.errors.append(exc_info)
+        test.errors.append(exc_info[2])
 
     def addFailure(self, test, exc_info, loads_status, agent_id=None):
         test = self._get_test(test, loads_status, agent_id)
-        test.failures.append(exc_info)
+        test.failures.append(exc_info[2])
 
     def startTest(self, test, loads_status=None, agent_id=None):
         hit, user = loads_status[:2]

--- a/loads/tests/test_output.py
+++ b/loads/tests/test_output.py
@@ -210,7 +210,11 @@ class TestFunkloadOutput(TestCase):
             output.push('add_hit', state, started=TIME1, elapsed=_1,
                         url='http://example.local/bar', method='GET',
                         status=500)
-            output.push('addFailure', test_case, ['mock', 'traceback'], state)
+            output.push(
+                'addFailure', test_case, (
+                    Exception, Exception('Mock Exception'),
+                    ['mock', 'traceback']),
+                state)
             output.push('stopTest', test_case, [1, 2, 3, 4])
 
             output.flush()


### PR DESCRIPTION
Store just the traceback. Update the tests to reflect.
