### PR TITLE
Don't try to import the test module until we've installed the deps.

### DIFF
--- a/loads/runners/local.py
+++ b/loads/runners/local.py
@@ -67,13 +67,6 @@ class LocalRunner(object):
         self.run_id = None
         self.project_name = args.get('project_name', 'N/A')
 
-        # Only resolve the name of the test if we're using the default python
-        # test-runner.
-        if args.get('test_runner') is None and self.fqn:
-            self.test = resolve_name(self.fqn)
-        else:
-            self.test = None
-
         self.outputs = []
         self.stop = False
 


### PR DESCRIPTION
The LocalRunner class currently tries to resolve the FQN of the test in its constructor.  This will fail if the script requires any extra python deps, since these are not installed until the _execute() method is called.

Since _execute() itself also contains logic to resolve the FQN, I've simply removed the apparently-redundant call to resolve_name in the constructor.  This seems to work OK in my tests so far.
