### PR TITLE
Add ssl support for IRC observer.

### DIFF
--- a/loads/tests/test_observer_irc.py
+++ b/loads/tests/test_observer_irc.py
@@ -51,7 +51,7 @@ class TestIRC(unittest2.TestCase):
 
     def test_send(self):
         results = 'yeah'
-        client = irc()
+        client = irc(ssl=False)
         client(results)
 
         # what did we send on IRC


### PR DESCRIPTION
The default IRC configuration tries to connect to irc.mozilla.org on an SSL port, but doesn't support SSL connections.  This patch adds the necessary hooks to support SSL connections along with an "observer_irc_ssl" option to control whether or not to use it.

To test, try running `./bin/python ./loads/observers/_irc.py` to output a test message to IRC.  It fails silently without this patch, works correctly with.
