### PR TITLE
Fix handling of redirects. Previously, if a url caused a redirect, the r...

### DIFF
--- a/loads/measure.py
+++ b/loads/measure.py
@@ -83,10 +83,11 @@ class Session(_Session):
         """If there is a redirect, need to record information about the hit before
         it is obliterated by the next request."""
         # Future version of requests (some time > 2.2.1) has Response.is_redirect
-        if ('location' in resp.headers) and resp.status_code in REDIRECT_STATI:
+        if 'location' in resp.headers and resp.status_code in REDIRECT_STATI:
             resp.started = self._started
             resp.method = req.method
             self._analyse_request(resp)
+            req._needs_analysis = False
         return _Session.resolve_redirects(self, resp, req, stream=stream, timeout=timeout,
                                           verify=verify,cert=cert,proxies=proxies)
 
@@ -94,20 +95,19 @@ class Session(_Session):
         """Do the actual request from within the session, doing some
         measures at the same time about the request (duration, status, etc).
         """
-        # Recording information about a hit may or may not take place here.
-        # If the hit is a redirect, it will clear the following flag when
-        # it records, so that we know not to do it twice.
-        self._need_to_analyse = True
+        # If the request receives a redirect response code, collecting the
+        # result will be handled by resolve_redirects() before the result
+        # object is thrown away to perform the redirect. In that case, this
+        # flag will be set to false, indicating that nothing needs to be
+        # (or should be) recorded at the end of this method.
+        request._needs_analysis = True
         # attach some information to the request object for later use.
         self._started = datetime.datetime.utcnow()
         res = _Session.send(self, request, **kwargs)
-        if hasattr(self, '_need_to_analyse'):
-            # Reaching this code means the url was not a redirect, and so still
-            # needs analysing.
+        if request._needs_analysis == True:
             res.started = self._started
             res.method = request.method
             self._analyse_request(res)
-            delattr(self, '_need_to_analyse')
         return res
 
     def _analyse_request(self, req):


### PR DESCRIPTION
...edirected url and time would be recorded twice(or more times for more redirects) in the results, as opposed to correct info for each individual request being recorded before the subsequent redirect.

I'll confess that I haven't done extensive testing of this, but it fixes the problem I was seeing for me. (In particular, I haven't run any of the tests included in the module, so apologies if this is just plain broken!).

The problem this addresses:
If the page that Session.send() is trying to access is a url that causes a redirect, from url a to url b say, then a hit is recorded for url b twice, with the start/elapsed time both being for url b, since the res.started /res.elapsed and res.url properties are all overwritten. This means that loads does not record any info for url a(although the total number of hits it records is correct, assuming that you are in fact interested in the redirect hits).
In practice, if there were several redirects, this means you would only record the last request, and that it would be recorded once for each request in the redirect chain that led to it.

The suggested fix below makes resolve_redirects() record information for the hit before attempting the redirected request. The final non-redirected request is still recorded in 'send'.

Notes:
- requests module has an is_redirect property being added to Response, which is not in the released 2.2.1 requests module. Depending on the next loads release date, it will probably be desirable to change the first line in resolve_redirects() to make use of this.
- I've made an assumption that the redirected hits are interesting enough to fix logging them properly. I could imagine that users of the module might want to know the total elapsed time from first url until the end of any redirects for the first link? (i.e: Still allow redirects, but don't count it as a separate hit), although personally I'm not all that fussed.
