### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,6 @@ See the docs at http://loads.readthedocs.io
 .. image:: https://coveralls.io/repos/mozilla-services/loads/badge.png?branch=master
    :target: https://coveralls.io/r/mozilla-services/loads
 
-.. image:: https://pypip.in/v/loads/badge.png
+.. image:: https://img.shields.io/pypi/v/loads.svg
    :target: https://crate.io/packages/loads/
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20loads))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `loads`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.